### PR TITLE
Set default editor background and text colors to match dark theme

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -8,12 +8,12 @@ from PyQt6.QtGui import QColor
 
 SETTINGS_FILE = "notehub_settings.json"
 DEFAULT_SETTINGS = {
-    "terminal_bg": "#1e1e1e",
-    "terminal_fg": "#00ff00",
+    "terminal_bg": "#1E1E1E",
+    "terminal_fg": "#00FF00",
     "vim_normal_border": "#2196F3",
     "vim_insert_border": "#4CAF50",
-    "editor_bg": "#ffffff",
-    "editor_fg": "#000000"
+    "editor_bg": "#1E1E1E",
+    "editor_fg": "#FFFFFF"
 }
 
 


### PR DESCRIPTION
This PR updates the default theme colors to the dark scheme described in Issue #<issue-number>.

Changes:
- Editor background → #1E1E1E
- Editor text → #FFFFFF
- Terminal background and text remain as requested
- Vim mode border colors already matched defaults

This change affects only the default values and does not remove the ability for users to customize colors later, as requested in the issue.

No functional behavior changed this is purely visual theme initialization.
